### PR TITLE
Add support for setting the unique source ID

### DIFF
--- a/src/Bonsai.Lsl/Bonsai.Lsl.csproj
+++ b/src/Bonsai.Lsl/Bonsai.Lsl.csproj
@@ -20,7 +20,7 @@
     <TargetFramework>net472</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Features>strict</Features>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Lsl/StreamOutlet.cs
+++ b/src/Bonsai.Lsl/StreamOutlet.cs
@@ -56,8 +56,16 @@ namespace Bonsai.Lsl
         [Description("The nominal sampling rate used by the data source, in Hz.")]
         public int SampleRate { get; set; }
 
-        [Description("A Unique identifier usually associated to the EEG device (eg. the MAC address)")]
-        public string UniqId { get; set; }
+        /// <summary>
+        /// Gets or sets the unique identifier of the stream data source.
+        /// </summary>
+        /// <remarks>
+        /// The unique source (or device) identifier is an optional piece of
+        /// information that, if available, allows endpoints to re-acquire
+        /// a stream automatically once it is back online.
+        /// </remarks>
+        [Description("The unique identifier of the stream data source.")]
+        public string SourceId { get; set; }
 
         /// <inheritdoc/>
         public override Expression Build(IEnumerable<Expression> arguments)
@@ -129,6 +137,7 @@ namespace Bonsai.Lsl
                 throw new InvalidOperationException("A valid LSL stream name must be specified.");
             }
 
+            var sourceId = SourceId;
             var sampleRate = SampleRate;
             var contentType = ContentType ?? typeof(TSource).Name;
             var channelCount = ChannelCount;
@@ -140,7 +149,7 @@ namespace Bonsai.Lsl
             return Observable.Using(
                 () =>
                 {
-                    var streamInfo = new StreamInfo(name, contentType, channelCount, sampleRate, channelFormat,UniqId);
+                    var streamInfo = new StreamInfo(name, contentType, channelCount, sampleRate, channelFormat, sourceId);
                     return new Native.StreamOutlet(streamInfo);
                 },
                 outlet => source.Do(value => writer(value, outlet)));

--- a/src/Bonsai.Lsl/StreamOutlet.cs
+++ b/src/Bonsai.Lsl/StreamOutlet.cs
@@ -56,6 +56,9 @@ namespace Bonsai.Lsl
         [Description("The nominal sampling rate used by the data source, in Hz.")]
         public int SampleRate { get; set; }
 
+        [Description("A Unique identifier usually associated to the EEG device (eg. the MAC address)")]
+        public string UniqId { get; set; }
+
         /// <inheritdoc/>
         public override Expression Build(IEnumerable<Expression> arguments)
         {
@@ -137,7 +140,7 @@ namespace Bonsai.Lsl
             return Observable.Using(
                 () =>
                 {
-                    var streamInfo = new StreamInfo(name, contentType, channelCount, sampleRate, channelFormat);
+                    var streamInfo = new StreamInfo(name, contentType, channelCount, sampleRate, channelFormat,UniqId);
                     return new Native.StreamOutlet(streamInfo);
                 },
                 outlet => source.Do(value => writer(value, outlet)));


### PR DESCRIPTION
Some LSL acquisition systems (e.g. Enobio) require the unique stream source ID to be set before they will accept a connection. This unique identifier is set at time of creation of the stream outlet.