### PR TITLE
Added postprocessing options for StreamInlet

### DIFF
--- a/src/Bonsai.Lsl/Bonsai.Lsl.csproj
+++ b/src/Bonsai.Lsl/Bonsai.Lsl.csproj
@@ -38,4 +38,10 @@
     <Content Include="..\liblsl\win-x64\bin\*.dll" PackagePath="runtimes\win-x64\native" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Native\LSL.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/src/Bonsai.Lsl/Bonsai.Lsl.csproj
+++ b/src/Bonsai.Lsl/Bonsai.Lsl.csproj
@@ -20,7 +20,7 @@
     <TargetFramework>net472</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Features>strict</Features>
-    <Version>0.2.0</Version>
+    <Version>0.2.1-rc1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Lsl/Bonsai.Lsl.csproj
+++ b/src/Bonsai.Lsl/Bonsai.Lsl.csproj
@@ -20,7 +20,7 @@
     <TargetFramework>net472</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Features>strict</Features>
-    <Version>0.2.1-rc1</Version>
+    <Version>0.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bonsai.Lsl/Bonsai.Lsl.csproj
+++ b/src/Bonsai.Lsl/Bonsai.Lsl.csproj
@@ -38,10 +38,4 @@
     <Content Include="..\liblsl\win-x64\bin\*.dll" PackagePath="runtimes\win-x64\native" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="Native\LSL.cs">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Compile>
-  </ItemGroup>
-
 </Project>

--- a/src/Bonsai.Lsl/StreamInlet.cs
+++ b/src/Bonsai.Lsl/StreamInlet.cs
@@ -325,6 +325,7 @@ namespace Bonsai.Lsl
     /// <summary>
     /// Specifies options for post-processing of samples for an LSL stream inlet.
     /// </summary>
+    [Flags]
     public enum ProcessingOptions
     {
         /// <summary>

--- a/src/Bonsai.Lsl/StreamInlet.cs
+++ b/src/Bonsai.Lsl/StreamInlet.cs
@@ -58,9 +58,9 @@ namespace Bonsai.Lsl
         public ChannelFormat ChannelFormat { get; set; } = ChannelFormat.Float32;
 
         /// <summary>
-        /// Gets or sets a value specifying the postprocessing time-synchronisation options to use on an LSL stream inlet.
+        /// Gets or sets a value specifying the postprocessing time synchronization options to use on the LSL stream.
         /// </summary>
-        [Description("Specifies the postprocessing options of an LSL stream inlet.")]
+        [Description("Specifies the postprocessing time synchronization options to use on the LSL stream.")]
         public ProcessingOptions ProcessingOptions { get; set; } = ProcessingOptions.All;
 
         /// <inheritdoc/>
@@ -221,7 +221,7 @@ namespace Bonsai.Lsl
             return streamInfo;
         }
 
-        static Native.StreamInlet CreateInlet(string name, string type, ProcessingOptions procFlags)
+        static Native.StreamInlet CreateInlet(string name, string type, ProcessingOptions processingFlags)
         {
             StreamInfo streamInfo;
             if (name is null && type is null)
@@ -237,7 +237,7 @@ namespace Bonsai.Lsl
                 streamInfo = ResolveStream("name", name);
             }
             else streamInfo = ResolveStream($"name='{name}' and type='{type}'");
-            return new Native.StreamInlet(streamInfo, postproc_flags: (processing_options_t)procFlags);
+            return new Native.StreamInlet(streamInfo, postproc_flags: (processing_options_t)processingFlags);
         }
 
         IObservable<Timestamped<TResult>> Generate<TResult>(Func<Native.StreamInlet, TResult[], double> pull_sample)
@@ -323,22 +323,22 @@ namespace Bonsai.Lsl
     }
 
     /// <summary>
-    /// Options for post-processing of samples for an LSL stream inlet.
+    /// Specifies options for post-processing of samples for an LSL stream inlet.
     /// </summary>
     public enum ProcessingOptions
     {
         /// <summary>
-        /// No automatic post-processing. Gives ground-truth timestamps for manual post-processing.
+        /// No automatic post-processing. Provides ground truth timestamps for manual post-processing.
         /// </summary>
         None = processing_options_t.proc_none,
 
         /// <summary>
-        /// Perform automatic clock-synchronisation.
+        /// Perform automatic clock synchronization.
         /// </summary>
         Clocksync = processing_options_t.proc_clocksync,
 
         /// <summary>
-        /// Remove jitter from timestamps.
+        /// Remove random jitter from timestamps using a trend-adjusted smoothing algorithm.
         /// </summary>
         Dejitter = processing_options_t.proc_dejitter,
 

--- a/src/Bonsai.Lsl/StreamInlet.cs
+++ b/src/Bonsai.Lsl/StreamInlet.cs
@@ -61,7 +61,7 @@ namespace Bonsai.Lsl
         /// Gets or sets a value specifying the postprocessing time-synchronisation options to use on an LSL stream inlet.
         /// </summary>
         [Description("Specifies the postprocessing options of an LSL stream inlet.")]
-        public ProcessingFlags ProcessingOptions { get; set; } = ProcessingFlags.All;
+        public ProcessingOptions ProcessingOptions { get; set; } = ProcessingOptions.All;
 
         /// <inheritdoc/>
         public override Expression Build(IEnumerable<Expression> arguments)
@@ -221,7 +221,7 @@ namespace Bonsai.Lsl
             return streamInfo;
         }
 
-        static Native.StreamInlet CreateInlet(string name, string type, ProcessingFlags procFlags)
+        static Native.StreamInlet CreateInlet(string name, string type, ProcessingOptions procFlags)
         {
             StreamInfo streamInfo;
             if (name is null && type is null)
@@ -325,7 +325,7 @@ namespace Bonsai.Lsl
     /// <summary>
     /// Options for post-processing of samples for an LSL stream inlet.
     /// </summary>
-    public enum ProcessingFlags
+    public enum ProcessingOptions
     {
         /// <summary>
         /// No automatic post-processing. Gives ground-truth timestamps for manual post-processing.


### PR DESCRIPTION
Previously, StreamInlet creation used the default options which resulted in no online correction of LSL timestamps. This PR adds options for the various postprocessing options in LSL StreamInlets, allowing for e.g. online clock sync and timestamp monotonization.