### PR TITLE
Add netstandard target

### DIFF
--- a/src/EmotionalCities.Lsl/EmotionalCities.Lsl.csproj
+++ b/src/EmotionalCities.Lsl/EmotionalCities.Lsl.csproj
@@ -17,7 +17,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
     <PackageTags>Bonsai Rx LSL Lab Streaming Layer</PackageTags>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Features>strict</Features>
     <Version>0.4.0</Version>


### PR DESCRIPTION
This PR adds a netstandard2.0 target for improved cross-platform compatibility with .NET core frameworks.