### PR TITLE
Update native runtime for wrapper compatibility

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -23,10 +23,10 @@ function Get-Dependency {
 
 Write-Host ("Downloading Dependencies")
 Get-Dependency -TargetFile ".\win-x64.zip" `
-               -TargetHash "6C70ACF16ECDA3CBD657F17D388079CD" `
-               -Uri "https://github.com/sccn/liblsl/releases/download/v1.16.0/liblsl-1.16.0-Win_amd64.zip"
+               -TargetHash "3B53DFE537C057DF1AF35AAE05D79F19" `
+               -Uri "https://github.com/sccn/liblsl/releases/download/v1.14.0/liblsl-1.14.0-Win_amd64.zip"
 Get-Dependency -TargetFile ".\win-x86.zip" `
-               -TargetHash "E5CAB1330CB42E665FB74B343A859DA4" `
-               -Uri "https://github.com/sccn/liblsl/releases/download/v1.16.0/liblsl-1.16.0-Win_i386.zip"
+               -TargetHash "359E62226CABEFF98D7646BCED3173DD" `
+               -Uri "https://github.com/sccn/liblsl/releases/download/v1.14.0/liblsl-1.14.0-Win_i386.zip"
 Write-Host ("Building EmotionalCities.Lsl")
 & dotnet build -c Release .\src\EmotionalCities.Lsl.sln

--- a/src/EmotionalCities.Lsl/EmotionalCities.Lsl.csproj
+++ b/src/EmotionalCities.Lsl/EmotionalCities.Lsl.csproj
@@ -20,7 +20,7 @@
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Features>strict</Features>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates the native LSL runtime to 1.14.0 to ensure managed wrapper compatibility. Future versions will update the binary runtime dependency, but they will require changing LSL.cs to a compatible version.

Unfortunately [labstreaminglayer/liblsl-Csharp](https://github.com/labstreaminglayer/liblsl-Csharp) does not seem to be maintained anymore.